### PR TITLE
Change showcase background color based on scroll position

### DIFF
--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect, useState } from 'react';
 import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
 

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -3,9 +3,18 @@ import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
 
 export default function Showcase() {
 	const [alpha, setAlpha] = useState('0.00');
+	const [hidden, setHidden] = useState(true);
 
 	function handleScroll() {
-		setAlpha(calculateScrollAlpha);
+		let scrollAlpha: string = calculateScrollAlpha();
+
+		if (scrollAlpha === '0.00') {
+			setHidden(true);
+		} else {
+			setHidden(false);
+		}
+
+		setAlpha(scrollAlpha);
 	}
 
 	useEffect(() => {
@@ -18,7 +27,9 @@ export default function Showcase() {
 
 	return (
 		<div
-			className="flex justify-center p-3 pt-[100vh]"
+			className={`flex justify-center p-3 ${
+				hidden ? 'mt-[100vh]' : 'pt-[100vh]'
+			}`}
 			style={{ backgroundColor: `rgba(0, 0, 0, ${alpha})` }}
 		>
 			<div className="flex-1 max-w-prose">

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -3,10 +3,8 @@ import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
 
 export default function Showcase() {
 	const [alpha, setAlpha] = useState(0);
-	const [hidden, setHidden] = useState(true);
 
 	function handleScroll() {
-		setHidden(calculateScrollAlpha() === 0);
 		setAlpha(calculateScrollAlpha());
 	}
 
@@ -21,7 +19,7 @@ export default function Showcase() {
 	return (
 		<div
 			className={`flex justify-center p-3 ${
-				hidden ? 'mt-[100vh]' : 'pt-[100vh]'
+				calculateScrollAlpha() === 0 ? 'mt-[100vh]' : 'pt-[100vh]'
 			}`}
 			style={{ backgroundColor: `rgba(0, 0, 0, ${alpha})` }}
 		>

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -11,6 +11,8 @@ export default function Showcase() {
 	}
 
 	useEffect(() => {
+		setAlpha(calculateScrollAlpha());
+
 		window.addEventListener('scroll', handleScroll);
 
 		return () => {
@@ -21,7 +23,7 @@ export default function Showcase() {
 	return (
 		<div
 			className={`flex justify-center p-3 ${
-				calculateScrollAlpha() === 0 ? 'mt-[100vh]' : 'pt-[100vh]'
+				alpha === 0 ? 'mt-[100vh]' : 'pt-[100vh]'
 			}`}
 			style={{ backgroundColor: `rgba(0, 0, 0, ${alpha})` }}
 		>

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -59,7 +59,7 @@ type ShowcaseItemProps = {
 
 function ShowcaseItem({ title, children }: ShowcaseItemProps) {
 	return (
-		<section className="pb-3">
+		<section className="p-2 pb-3">
 			<h2 className="font-serif text-xl">{title}</h2>
 			<pre className="font-sans whitespace-normal">{children}</pre>
 		</section>

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -6,15 +6,8 @@ export default function Showcase() {
 	const [hidden, setHidden] = useState(true);
 
 	function handleScroll() {
-		let scrollAlpha: string = calculateScrollAlpha();
-
-		if (scrollAlpha === '0.00') {
-			setHidden(true);
-		} else {
-			setHidden(false);
-		}
-
-		setAlpha(scrollAlpha);
+		setHidden(calculateScrollAlpha() === '0.00');
+		setAlpha(calculateScrollAlpha());
 	}
 
 	useEffect(() => {

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -1,6 +1,26 @@
+import { useEffect, useState } from 'react';
+import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
+
 export default function Showcase() {
+	const [alpha, setAlpha] = useState('0.00');
+
+	function handleScroll() {
+		setAlpha(calculateScrollAlpha);
+	}
+
+	useEffect(() => {
+		window.addEventListener('scroll', handleScroll);
+
+		return () => {
+			window.removeEventListener('scroll', handleScroll);
+		};
+	}, []);
+
 	return (
-		<div className="flex justify-center p-5 mt-[100vh] bg-black">
+		<div
+			className="flex justify-center p-3 pt-[100vh]"
+			style={{ backgroundColor: `rgba(0, 0, 0, ${alpha})` }}
+		>
 			<div className="flex-1 max-w-prose">
 				<h1 className="p-3 text-center font-serif text-2xl">
 					{'Photography'}

--- a/src/app/components/showcase.tsx
+++ b/src/app/components/showcase.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react';
 import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
 
 export default function Showcase() {
-	const [alpha, setAlpha] = useState('0.00');
+	const [alpha, setAlpha] = useState(0);
 	const [hidden, setHidden] = useState(true);
 
 	function handleScroll() {
-		setHidden(calculateScrollAlpha() === '0.00');
+		setHidden(calculateScrollAlpha() === 0);
 		setAlpha(calculateScrollAlpha());
 	}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Introduction from '@/app/components/introduction';
 import Showcase from '@/app/components/showcase';
 import Header from '@/components/header';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Introduction from '@/app/components/introduction';
 import Showcase from '@/app/components/showcase';
 import Header from '@/components/header';

--- a/src/scripts/calculateScrollAlpha.ts
+++ b/src/scripts/calculateScrollAlpha.ts
@@ -1,6 +1,9 @@
-export default function calculateScrollAlpha():string {
-  return Math.min(
-    window.scrollY / (window.innerHeight / 3),
+export default function calculateScrollAlpha():number {
+  const threshold = 3;
+  const scrollAlpha = Math.min(
+    window.scrollY / (window.innerHeight / threshold),
     1,
-  ).toFixed(2);
+  );
+
+  return parseFloat(scrollAlpha.toFixed(2));
 }

--- a/src/scripts/calculateScrollAlpha.ts
+++ b/src/scripts/calculateScrollAlpha.ts
@@ -1,0 +1,6 @@
+export default function calculateScrollAlpha() {
+  return Math.min(
+    window.scrollY / (window.innerHeight / 3),
+    1,
+  ).toFixed(2);
+}

--- a/src/scripts/calculateScrollAlpha.ts
+++ b/src/scripts/calculateScrollAlpha.ts
@@ -1,4 +1,4 @@
-export default function calculateScrollAlpha() {
+export default function calculateScrollAlpha():string {
   return Math.min(
     window.scrollY / (window.innerHeight / 3),
     1,


### PR DESCRIPTION
### Files added
Added a calculateScrollAlpha.ts file to contain the script that calculates the alpha value based on the scroll position.

### Things changed
The showcase component has been updated to import the alpha value from calculateScrollAlpha.ts. Then, using useEffect and event listeners, the background color of the showcase component is updated based on the alpha value and scroll position.

In order for the showcase background to take up the entire page, padding is used on the element. However, this blocks elements behind it. Therefore, some additional code is added so that when the alpha value is set to "0.00" (aka, showcase is hidden), the padding on the element is swapped out for margin so that showcase retains its position, but elements below it can be selected and highlighted. 