### PR TITLE
Add optional scroll prop

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function Contact() {
 	return (
 		<>
-			<Header page="contact" />
+			<Header />
 			<Content title="Contact">
 				<pre className="font-sans whitespace-normal max-w-prose">
 					My name is Joe, but you can call me anytime.

--- a/src/app/music/music.tsx
+++ b/src/app/music/music.tsx
@@ -11,7 +11,7 @@ import { songs, SongTypes } from './songs';
 export default function MusicContent() {
 	return (
 		<>
-			<Header page="music" />
+			<Header />
 			<Content title="Music">
 				<div className="flex flex-col items-center">
 					<Image

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import Footer from '@/components/footer';
 export default function Home() {
 	return (
 		<>
-			<Header page="home" />
+			<Header scroll={true} />
 			<main className="flex-1">
 				<Introduction />
 				<Showcase />

--- a/src/app/photography/page.tsx
+++ b/src/app/photography/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function Photography() {
 	return (
 		<>
-			<Header page="photography" />
+			<Header />
 			<Content title="Photography">
 				<pre className="font-sans whitespace-normal max-w-prose">
 					This is the photography page.

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default function Projects() {
 	return (
 		<>
-			<Header page="projects" />
+			<Header />
 			<Content title="Projects">
 				<div>
 					{projects.map((project: ProjectTypes) => (

--- a/src/app/videos/videos.tsx
+++ b/src/app/videos/videos.tsx
@@ -53,7 +53,7 @@ export default function VideosContent() {
 
 	return (
 		<>
-			<Header page="videos" />
+			<Header />
 			<Content title="Videos">
 				<div>
 					<div className="w-full pb-12">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -8,10 +8,10 @@ import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
 import Navigation from './navigation';
 
 type HeaderProps = {
-	page: string;
+	scroll?: boolean;
 };
 
-export default function Header({ page }: HeaderProps) {
+export default function Header({ scroll }: HeaderProps) {
 	const [color, setColor] = useState(0);
 
 	function handleScroll() {
@@ -19,7 +19,7 @@ export default function Header({ page }: HeaderProps) {
 	}
 
 	useEffect(() => {
-		if (page !== 'home') {
+		if (!scroll) {
 			setColor(255);
 			return;
 		}


### PR DESCRIPTION
Instead of specifying what page you are on with the `page` header prop, then only running the scroll functionality when you're on the home page, we can instead just use an optional `scroll` prop and set it to `true` if you want the scroll effect