### PR TITLE
Make introduction black when scrollAlpha is 1

### DIFF
--- a/src/app/components/introduction.tsx
+++ b/src/app/components/introduction.tsx
@@ -1,10 +1,34 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { content } from './content';
+import calculateScrollAlpha from '@/scripts/calculateScrollAlpha';
 import profilePicture from '../../../public/profile-picture.jpg';
 
 export default function Introduction() {
+	const [alpha, setAlpha] = useState(0);
+
+	function handleScroll() {
+		setAlpha(calculateScrollAlpha());
+	}
+
+	useEffect(() => {
+		setAlpha(calculateScrollAlpha());
+
+		window.addEventListener('scroll', handleScroll);
+
+		return () => {
+			window.removeEventListener('scroll', handleScroll);
+		};
+	}, []);
+
 	return (
-		<div className="fixed top-0 left-0 w-full h-full flex items-center justify-center -z-10 bg-vertical lg:bg-horizontal bg-cover bg-center">
+		<div
+			className={`${
+				alpha === 1 ? 'hidden' : ''
+			} fixed top-0 left-0 w-full h-full flex items-center justify-center -z-10 bg-vertical lg:bg-horizontal bg-cover bg-center`}
+		>
 			<div className="flex flex-col items-center p-3">
 				<Image
 					src={profilePicture}


### PR DESCRIPTION
When scrollAlpha is 1, set the introduction to `hidden`. This will help keep the bottom of the page black when scrolling on iOS browsers. 